### PR TITLE
Add JSON round-trip support for PagedList and ImmutableList

### DIFF
--- a/src/Jeebs/Functions/JsonF.cs
+++ b/src/Jeebs/Functions/JsonF.cs
@@ -40,6 +40,8 @@ public static partial class JsonF
 		Options.Converters.Add(new DateTimeIntJsonConverter());
 		Options.Converters.Add(new DateTimeJsonConverter());
 		Options.Converters.Add(new EnumeratedJsonConverterFactory());
+		Options.Converters.Add(new ImmutableListJsonConverterFactory());
+		Options.Converters.Add(new PagedListJsonConverterFactory());
 		Options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
 	}
 }

--- a/src/Jeebs/Internals/JsonConverters/ImmutableListJsonConverter.cs
+++ b/src/Jeebs/Internals/JsonConverters/ImmutableListJsonConverter.cs
@@ -1,0 +1,43 @@
+// Jeebs Rapid Application Development
+// Copyright (c) bfren - licensed under https://mit.bfren.dev/2013
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Jeebs.Collections;
+
+namespace Jeebs.Internals.JsonConverters;
+
+/// <summary>
+/// JSON converter for <see cref="ImmutableList{T}"/> objects. Round-trips as a plain JSON array.
+/// </summary>
+/// <typeparam name="T">Item type.</typeparam>
+internal sealed class ImmutableListJsonConverter<T> : JsonConverter<ImmutableList<T>>
+{
+	/// <summary>
+	/// Read an <see cref="ImmutableList{T}"/> from a JSON array.
+	/// </summary>
+	/// <exception cref="JsonException"/>
+	public override ImmutableList<T>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		if (reader.TokenType == JsonTokenType.Null)
+		{
+			return null;
+		}
+
+		if (reader.TokenType != JsonTokenType.StartArray)
+		{
+			throw new JsonException($"Expected StartArray for {typeof(ImmutableList<T>)}, got {reader.TokenType}.");
+		}
+
+		var items = JsonSerializer.Deserialize<List<T>>(ref reader, options);
+		return new ImmutableList<T>(items ?? []);
+	}
+
+	/// <summary>
+	/// Write an <see cref="ImmutableList{T}"/> as a JSON array.
+	/// </summary>
+	public override void Write(Utf8JsonWriter writer, ImmutableList<T> value, JsonSerializerOptions options) =>
+		JsonSerializer.Serialize(writer, value.AsEnumerable(), options);
+}

--- a/src/Jeebs/Internals/JsonConverters/ImmutableListJsonConverterFactory.cs
+++ b/src/Jeebs/Internals/JsonConverters/ImmutableListJsonConverterFactory.cs
@@ -1,0 +1,46 @@
+// Jeebs Rapid Application Development
+// Copyright (c) bfren - licensed under https://mit.bfren.dev/2013
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Jeebs.Collections;
+
+namespace Jeebs.Internals.JsonConverters;
+
+/// <summary>
+/// JSON converter factory for <see cref="ImmutableList{T}"/> objects.
+/// </summary>
+internal sealed class ImmutableListJsonConverterFactory : JsonConverterFactory
+{
+	/// <summary>
+	/// Returns true if <paramref name="typeToConvert"/> is exactly a closed generic <see cref="ImmutableList{T}"/>.
+	/// </summary>
+	/// <remarks>
+	/// Exact match only — subclasses such as <see cref="PagedList{T}"/> are handled by their own factory.
+	/// </remarks>
+	/// <param name="typeToConvert">Type to convert.</param>
+	public override bool CanConvert(Type typeToConvert) =>
+		typeToConvert.IsGenericType
+		&& typeToConvert.GetGenericTypeDefinition() == typeof(ImmutableList<>);
+
+	/// <summary>
+	/// Create an <see cref="ImmutableListJsonConverter{T}"/> for the closed generic type.
+	/// </summary>
+	/// <param name="typeToConvert">Closed <see cref="ImmutableList{T}"/> type.</param>
+	/// <param name="options">JsonSerializerOptions.</param>
+	/// <exception cref="JsonException"/>
+	public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+	{
+		var itemType = typeToConvert.GetGenericArguments()[0];
+		var converterType = typeof(ImmutableListJsonConverter<>).MakeGenericType(itemType);
+		return Activator.CreateInstance(converterType) switch
+		{
+			JsonConverter x =>
+				x,
+
+			_ =>
+				throw new JsonException($"Unable to create {typeof(ImmutableListJsonConverter<>)} for type {typeToConvert}.")
+		};
+	}
+}

--- a/src/Jeebs/Internals/JsonConverters/PagedListJsonConverter.cs
+++ b/src/Jeebs/Internals/JsonConverters/PagedListJsonConverter.cs
@@ -1,0 +1,108 @@
+// Jeebs Rapid Application Development
+// Copyright (c) bfren - licensed under https://mit.bfren.dev/2013
+
+using System;
+using System.Collections.Generic;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Jeebs.Collections;
+
+namespace Jeebs.Internals.JsonConverters;
+
+/// <summary>
+/// JSON converter for <see cref="PagedList{T}"/> objects. Round-trips as
+/// <c>{ "values": { ...PagingValues... }, "items": [ ... ] }</c>.
+/// </summary>
+/// <typeparam name="T">Item type.</typeparam>
+internal sealed class PagedListJsonConverter<T> : JsonConverter<PagedList<T>>
+{
+	/// <summary>
+	/// Read a <see cref="PagedList{T}"/> from a JSON object.
+	/// </summary>
+	/// <exception cref="JsonException"/>
+	public override PagedList<T>? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+	{
+		if (reader.TokenType == JsonTokenType.Null)
+		{
+			return null;
+		}
+
+		if (reader.TokenType != JsonTokenType.StartObject)
+		{
+			throw new JsonException($"Expected StartObject for {typeof(PagedList<T>)}, got {reader.TokenType}.");
+		}
+
+		var valuesName = options.PropertyNamingPolicy?.ConvertName("Values") ?? "Values";
+		var itemsName = options.PropertyNamingPolicy?.ConvertName("Items") ?? "Items";
+
+		PagingValues? values = null;
+		List<T>? items = null;
+
+		while (reader.Read())
+		{
+			if (reader.TokenType == JsonTokenType.EndObject)
+			{
+				return new PagedList<T>(values ?? new PagingValues(), items ?? []);
+			}
+
+			if (reader.TokenType != JsonTokenType.PropertyName)
+			{
+				throw new JsonException($"Expected PropertyName in {typeof(PagedList<T>)}, got {reader.TokenType}.");
+			}
+
+			var propName = reader.GetString();
+			reader.Read();
+
+			if (string.Equals(propName, valuesName, StringComparison.OrdinalIgnoreCase))
+			{
+				values = JsonSerializer.Deserialize<PagingValues>(ref reader, options);
+			}
+			else if (string.Equals(propName, itemsName, StringComparison.OrdinalIgnoreCase))
+			{
+				items = JsonSerializer.Deserialize<List<T>>(ref reader, options);
+			}
+			else
+			{
+				reader.Skip();
+			}
+		}
+
+		throw new JsonException($"Unexpected end of JSON while reading {typeof(PagedList<T>)}.");
+	}
+
+	/// <summary>
+	/// Write a <see cref="PagedList{T}"/> as a JSON object with <c>values</c> and <c>items</c>.
+	/// </summary>
+	public override void Write(Utf8JsonWriter writer, PagedList<T> value, JsonSerializerOptions options)
+	{
+		var valuesName = options.PropertyNamingPolicy?.ConvertName("Values") ?? "Values";
+		var itemsName = options.PropertyNamingPolicy?.ConvertName("Items") ?? "Items";
+
+		// Coerce IPagingValues to the concrete PagingValues record so System.Text.Json
+		// picks up the init-settable properties for serialisation.
+		var concreteValues = value.Values as PagingValues ?? new PagingValues
+		{
+			Items = value.Values.Items,
+			ItemsPer = value.Values.ItemsPer,
+			FirstItem = value.Values.FirstItem,
+			LastItem = value.Values.LastItem,
+			Page = value.Values.Page,
+			Pages = value.Values.Pages,
+			PagesPer = value.Values.PagesPer,
+			LowerPage = value.Values.LowerPage,
+			UpperPage = value.Values.UpperPage,
+			Skip = value.Values.Skip,
+			Take = value.Values.Take
+		};
+
+		writer.WriteStartObject();
+
+		writer.WritePropertyName(valuesName);
+		JsonSerializer.Serialize(writer, concreteValues, options);
+
+		writer.WritePropertyName(itemsName);
+		JsonSerializer.Serialize(writer, value.AsEnumerable(), options);
+
+		writer.WriteEndObject();
+	}
+}

--- a/src/Jeebs/Internals/JsonConverters/PagedListJsonConverterFactory.cs
+++ b/src/Jeebs/Internals/JsonConverters/PagedListJsonConverterFactory.cs
@@ -1,0 +1,43 @@
+// Jeebs Rapid Application Development
+// Copyright (c) bfren - licensed under https://mit.bfren.dev/2013
+
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Jeebs.Collections;
+
+namespace Jeebs.Internals.JsonConverters;
+
+/// <summary>
+/// JSON converter factory for <see cref="PagedList{T}"/> objects.
+/// </summary>
+internal sealed class PagedListJsonConverterFactory : JsonConverterFactory
+{
+	/// <summary>
+	/// Returns true if <paramref name="typeToConvert"/> is a closed generic <see cref="PagedList{T}"/>.
+	/// </summary>
+	/// <param name="typeToConvert">Type to convert.</param>
+	public override bool CanConvert(Type typeToConvert) =>
+		typeToConvert.IsGenericType
+		&& typeToConvert.GetGenericTypeDefinition() == typeof(PagedList<>);
+
+	/// <summary>
+	/// Create a <see cref="PagedListJsonConverter{T}"/> for the closed generic type.
+	/// </summary>
+	/// <param name="typeToConvert">Closed <see cref="PagedList{T}"/> type.</param>
+	/// <param name="options">JsonSerializerOptions.</param>
+	/// <exception cref="JsonException"/>
+	public override JsonConverter CreateConverter(Type typeToConvert, JsonSerializerOptions options)
+	{
+		var itemType = typeToConvert.GetGenericArguments()[0];
+		var converterType = typeof(PagedListJsonConverter<>).MakeGenericType(itemType);
+		return Activator.CreateInstance(converterType) switch
+		{
+			JsonConverter x =>
+				x,
+
+			_ =>
+				throw new JsonException($"Unable to create {typeof(PagedListJsonConverter<>)} for type {typeToConvert}.")
+		};
+	}
+}

--- a/tests/Tests.Jeebs/Collections/ImmutableList/Roundtrip_Tests.cs
+++ b/tests/Tests.Jeebs/Collections/ImmutableList/Roundtrip_Tests.cs
@@ -1,0 +1,67 @@
+// Jeebs Unit Tests
+// Copyright (c) bfren - licensed under https://mit.bfren.dev/2013
+
+using Jeebs.Functions;
+
+namespace Jeebs.Collections.ImmutableList_Tests;
+
+public class Roundtrip_Tests
+{
+	[Fact]
+	public void Empty_ImmutableList_Roundtrips()
+	{
+		// Arrange
+		var original = new ImmutableList<int>();
+
+		// Act
+		var json = JsonF.Serialise(original).Unwrap(_ => string.Empty);
+		var result = JsonF.Deserialise<ImmutableList<int>>(json).Unwrap(_ => new());
+
+		// Assert
+		Assert.Empty(result);
+	}
+
+	[Fact]
+	public void Populated_ImmutableList_Of_Int_Roundtrips()
+	{
+		// Arrange
+		var original = new ImmutableList<int>([3, 1, 4, 1, 5, 9, 2, 6]);
+
+		// Act
+		var json = JsonF.Serialise(original).Unwrap(_ => string.Empty);
+		var result = JsonF.Deserialise<ImmutableList<int>>(json).Unwrap(_ => new());
+
+		// Assert
+		Assert.Equal(8, result.Count);
+		Assert.Collection(result,
+			x => Assert.Equal(3, x),
+			x => Assert.Equal(1, x),
+			x => Assert.Equal(4, x),
+			x => Assert.Equal(1, x),
+			x => Assert.Equal(5, x),
+			x => Assert.Equal(9, x),
+			x => Assert.Equal(2, x),
+			x => Assert.Equal(6, x)
+		);
+	}
+
+	[Fact]
+	public void ImmutableList_Of_Record_Roundtrips()
+	{
+		// Arrange
+		var original = new ImmutableList<Sample>([new Sample(1, "a"), new Sample(2, "b")]);
+
+		// Act
+		var json = JsonF.Serialise(original).Unwrap(_ => string.Empty);
+		var result = JsonF.Deserialise<ImmutableList<Sample>>(json).Unwrap(_ => new());
+
+		// Assert
+		Assert.Equal(2, result.Count);
+		Assert.Collection(result,
+			x => Assert.Equal(new Sample(1, "a"), x),
+			x => Assert.Equal(new Sample(2, "b"), x)
+		);
+	}
+
+	public sealed record class Sample(int Id, string Name);
+}

--- a/tests/Tests.Jeebs/Collections/PagedList/Roundtrip_Tests.cs
+++ b/tests/Tests.Jeebs/Collections/PagedList/Roundtrip_Tests.cs
@@ -1,0 +1,94 @@
+// Jeebs Unit Tests
+// Copyright (c) bfren - licensed under https://mit.bfren.dev/2013
+
+using Jeebs.Functions;
+
+namespace Jeebs.Collections.PagedList_Tests;
+
+public class Roundtrip_Tests
+{
+	[Fact]
+	public void Empty_PagedList_Roundtrips()
+	{
+		// Arrange
+		var original = new PagedList<int>();
+
+		// Act
+		var json = JsonF.Serialise(original).Unwrap(_ => string.Empty);
+		var result = JsonF.Deserialise<PagedList<int>>(json).Unwrap(_ => new());
+
+		// Assert
+		Assert.Empty(result);
+		Assert.Equal(new PagingValues(), result.Values);
+	}
+
+	[Fact]
+	public void Populated_PagedList_Of_Int_Roundtrips()
+	{
+		// Arrange
+		var values = new PagingValues(items: 10, page: 2, itemsPer: 5, pagesPer: 3);
+		var original = new PagedList<int>(values, [6, 7, 8, 9, 10]);
+
+		// Act
+		var json = JsonF.Serialise(original).Unwrap(_ => string.Empty);
+		var result = JsonF.Deserialise<PagedList<int>>(json).Unwrap(_ => new());
+
+		// Assert
+		Assert.Equal(5, result.Count);
+		Assert.Collection(result,
+			x => Assert.Equal(6, x),
+			x => Assert.Equal(7, x),
+			x => Assert.Equal(8, x),
+			x => Assert.Equal(9, x),
+			x => Assert.Equal(10, x)
+		);
+		Assert.Equal(values, result.Values);
+	}
+
+	[Fact]
+	public void Preserves_All_PagingValues_Fields()
+	{
+		// Arrange
+		var values = new PagingValues(items: 47, page: 3, itemsPer: 5, pagesPer: 4);
+		var original = new PagedList<int>(values, [11, 12, 13, 14, 15]);
+
+		// Act
+		var json = JsonF.Serialise(original).Unwrap(_ => string.Empty);
+		var result = JsonF.Deserialise<PagedList<int>>(json).Unwrap(_ => new());
+
+		// Assert
+		Assert.Equal(values.Items, result.Values.Items);
+		Assert.Equal(values.ItemsPer, result.Values.ItemsPer);
+		Assert.Equal(values.FirstItem, result.Values.FirstItem);
+		Assert.Equal(values.LastItem, result.Values.LastItem);
+		Assert.Equal(values.Page, result.Values.Page);
+		Assert.Equal(values.Pages, result.Values.Pages);
+		Assert.Equal(values.PagesPer, result.Values.PagesPer);
+		Assert.Equal(values.LowerPage, result.Values.LowerPage);
+		Assert.Equal(values.UpperPage, result.Values.UpperPage);
+		Assert.Equal(values.Skip, result.Values.Skip);
+		Assert.Equal(values.Take, result.Values.Take);
+	}
+
+	[Fact]
+	public void PagedList_Of_Record_Roundtrips()
+	{
+		// Arrange
+		var when = new DateTime(2026, 5, 16, 12, 30, 45, DateTimeKind.Utc);
+		var values = new PagingValues(items: 2, page: 1);
+		var original = new PagedList<Sample>(values, [new Sample(1, "a", when), new Sample(2, "b", when)]);
+
+		// Act
+		var json = JsonF.Serialise(original).Unwrap(_ => string.Empty);
+		var result = JsonF.Deserialise<PagedList<Sample>>(json).Unwrap(_ => new());
+
+		// Assert
+		Assert.Equal(2, result.Count);
+		Assert.Collection(result,
+			x => Assert.Equal(new Sample(1, "a", when), x),
+			x => Assert.Equal(new Sample(2, "b", when), x)
+		);
+	}
+
+	public sealed record class Sample(int Id, string Name, DateTime When);
+}

--- a/tests/Tests.Jeebs/Internals/JsonConverters/ImmutableListJsonConverter/ReadJson_Tests.cs
+++ b/tests/Tests.Jeebs/Internals/JsonConverters/ImmutableListJsonConverter/ReadJson_Tests.cs
@@ -1,0 +1,70 @@
+// Jeebs Unit Tests
+// Copyright (c) bfren - licensed under https://mit.bfren.dev/2013
+
+using System.Text.Json;
+using Jeebs.Collections;
+
+namespace Jeebs.Internals.JsonConverters.ImmutableListJsonConverter_Tests;
+
+public class ReadJson_Tests : Setup
+{
+	[Fact]
+	public void Deserialise_Array_Returns_ImmutableList()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var json = /*lang=json,strict*/ "[1,2,3]";
+
+		// Act
+		var result = JsonSerializer.Deserialize<ImmutableList<int>>(json, opt);
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.Equal(3, result.Count);
+		Assert.Collection(result,
+			x => Assert.Equal(1, x),
+			x => Assert.Equal(2, x),
+			x => Assert.Equal(3, x)
+		);
+	}
+
+	[Fact]
+	public void Deserialise_Empty_Array_Returns_Empty_ImmutableList()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var json = /*lang=json,strict*/ "[]";
+
+		// Act
+		var result = JsonSerializer.Deserialize<ImmutableList<int>>(json, opt);
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.Empty(result);
+	}
+
+	[Fact]
+	public void Deserialise_Null_Returns_Null()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var json = "null";
+
+		// Act
+		var result = JsonSerializer.Deserialize<ImmutableList<int>>(json, opt);
+
+		// Assert
+		Assert.Null(result);
+	}
+
+	[Fact]
+	public void Deserialise_Non_Array_Token_Throws()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var json = /*lang=json,strict*/ "{\"foo\":1}";
+
+		// Act + Assert
+		Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<ImmutableList<int>>(json, opt));
+	}
+}

--- a/tests/Tests.Jeebs/Internals/JsonConverters/ImmutableListJsonConverter/WriteJson_Tests.cs
+++ b/tests/Tests.Jeebs/Internals/JsonConverters/ImmutableListJsonConverter/WriteJson_Tests.cs
@@ -1,0 +1,38 @@
+// Jeebs Unit Tests
+// Copyright (c) bfren - licensed under https://mit.bfren.dev/2013
+
+using System.Text.Json;
+using Jeebs.Collections;
+
+namespace Jeebs.Internals.JsonConverters.ImmutableListJsonConverter_Tests;
+
+public class WriteJson_Tests : Setup
+{
+	[Fact]
+	public void Empty_List_Writes_Empty_Array()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var list = new ImmutableList<int>();
+
+		// Act
+		var json = JsonSerializer.Serialize(list, opt);
+
+		// Assert
+		Assert.Equal("[]", json);
+	}
+
+	[Fact]
+	public void Populated_List_Writes_Json_Array_In_Order()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var list = new ImmutableList<int>([3, 1, 4, 1, 5]);
+
+		// Act
+		var json = JsonSerializer.Serialize(list, opt);
+
+		// Assert
+		Assert.Equal("[3,1,4,1,5]", json);
+	}
+}

--- a/tests/Tests.Jeebs/Internals/JsonConverters/ImmutableListJsonConverter/_Setup.cs
+++ b/tests/Tests.Jeebs/Internals/JsonConverters/ImmutableListJsonConverter/_Setup.cs
@@ -1,0 +1,20 @@
+// Jeebs Unit Tests
+// Copyright (c) bfren - licensed under https://mit.bfren.dev/2013
+
+using System.Text.Json;
+
+namespace Jeebs.Internals.JsonConverters.ImmutableListJsonConverter_Tests;
+
+public abstract class Setup
+{
+	public JsonSerializerOptions GetOptions()
+	{
+		var opt = new JsonSerializerOptions
+		{
+			PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+		};
+		opt.Converters.Add(new ImmutableListJsonConverterFactory());
+
+		return opt;
+	}
+}

--- a/tests/Tests.Jeebs/Internals/JsonConverters/PagedListJsonConverter/ReadJson_Tests.cs
+++ b/tests/Tests.Jeebs/Internals/JsonConverters/PagedListJsonConverter/ReadJson_Tests.cs
@@ -1,0 +1,139 @@
+// Jeebs Unit Tests
+// Copyright (c) bfren - licensed under https://mit.bfren.dev/2013
+
+using System.Text.Json;
+using Jeebs.Collections;
+
+namespace Jeebs.Internals.JsonConverters.PagedListJsonConverter_Tests;
+
+public class ReadJson_Tests : Setup
+{
+	[Fact]
+	public void Deserialise_Object_Returns_PagedList_With_Values_And_Items()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var json = /*lang=json,strict*/ "{\"values\":{\"items\":10,\"itemsPer\":5,\"page\":2},\"items\":[6,7,8,9,10]}";
+
+		// Act
+		var result = JsonSerializer.Deserialize<PagedList<int>>(json, opt);
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.Equal(5, result.Count);
+		Assert.Collection(result,
+			x => Assert.Equal(6, x),
+			x => Assert.Equal(7, x),
+			x => Assert.Equal(8, x),
+			x => Assert.Equal(9, x),
+			x => Assert.Equal(10, x)
+		);
+		Assert.Equal(10ul, result.Values.Items);
+		Assert.Equal(5ul, result.Values.ItemsPer);
+		Assert.Equal(2ul, result.Values.Page);
+	}
+
+	[Fact]
+	public void Deserialise_Empty_Items_Returns_Empty_PagedList()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var json = /*lang=json,strict*/ "{\"values\":{\"items\":0,\"page\":1},\"items\":[]}";
+
+		// Act
+		var result = JsonSerializer.Deserialize<PagedList<int>>(json, opt);
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.Empty(result);
+	}
+
+	[Fact]
+	public void Deserialise_Missing_Values_Returns_Default_PagingValues()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var json = /*lang=json,strict*/ "{\"items\":[1,2,3]}";
+
+		// Act
+		var result = JsonSerializer.Deserialize<PagedList<int>>(json, opt);
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.Equal(3, result.Count);
+		Assert.Equal(new PagingValues(), result.Values);
+	}
+
+	[Fact]
+	public void Deserialise_Missing_Items_Returns_Empty_List_With_Values()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var json = /*lang=json,strict*/ "{\"values\":{\"items\":5,\"page\":1}}";
+
+		// Act
+		var result = JsonSerializer.Deserialize<PagedList<int>>(json, opt);
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.Empty(result);
+		Assert.Equal(5ul, result.Values.Items);
+	}
+
+	[Fact]
+	public void Deserialise_Ignores_Unknown_Properties()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var json = /*lang=json,strict*/ "{\"values\":{\"page\":1},\"extra\":123,\"items\":[42]}";
+
+		// Act
+		var result = JsonSerializer.Deserialize<PagedList<int>>(json, opt);
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.Single(result);
+		Assert.Equal(42, result[0]);
+	}
+
+	[Fact]
+	public void Deserialise_Is_Case_Insensitive_For_Property_Names()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var json = /*lang=json,strict*/ "{\"Values\":{\"items\":1,\"page\":1},\"Items\":[99]}";
+
+		// Act
+		var result = JsonSerializer.Deserialize<PagedList<int>>(json, opt);
+
+		// Assert
+		Assert.NotNull(result);
+		Assert.Single(result);
+		Assert.Equal(99, result[0]);
+	}
+
+	[Fact]
+	public void Deserialise_Non_Object_Token_Throws()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var json = /*lang=json,strict*/ "[1,2,3]";
+
+		// Act + Assert
+		Assert.Throws<JsonException>(() => JsonSerializer.Deserialize<PagedList<int>>(json, opt));
+	}
+
+	[Fact]
+	public void Deserialise_Null_Returns_Null()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var json = "null";
+
+		// Act
+		var result = JsonSerializer.Deserialize<PagedList<int>>(json, opt);
+
+		// Assert
+		Assert.Null(result);
+	}
+}

--- a/tests/Tests.Jeebs/Internals/JsonConverters/PagedListJsonConverter/WriteJson_Tests.cs
+++ b/tests/Tests.Jeebs/Internals/JsonConverters/PagedListJsonConverter/WriteJson_Tests.cs
@@ -1,0 +1,107 @@
+// Jeebs Unit Tests
+// Copyright (c) bfren - licensed under https://mit.bfren.dev/2013
+
+using System.Text.Json;
+using Jeebs.Collections;
+
+namespace Jeebs.Internals.JsonConverters.PagedListJsonConverter_Tests;
+
+public class WriteJson_Tests : Setup
+{
+	[Fact]
+	public void Empty_PagedList_Writes_Object_With_Empty_Items_Array()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var list = new PagedList<int>();
+
+		// Act
+		var json = JsonSerializer.Serialize(list, opt);
+
+		// Assert
+		Assert.StartsWith("{", json);
+		Assert.EndsWith("}", json);
+		Assert.Contains("\"values\":", json);
+		Assert.Contains("\"items\":[]", json);
+	}
+
+	[Fact]
+	public void Populated_PagedList_Writes_Items_And_Values()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var values = new PagingValues(items: 10, page: 2, itemsPer: 5, pagesPer: 3);
+		var list = new PagedList<int>(values, [6, 7, 8, 9, 10]);
+
+		// Act
+		var json = JsonSerializer.Serialize(list, opt);
+
+		// Assert
+		Assert.Contains("\"items\":[6,7,8,9,10]", json);
+		Assert.Contains("\"page\":2", json);
+		Assert.Contains("\"itemsPer\":5", json);
+	}
+
+	[Fact]
+	public void Writes_All_PagingValues_Properties_In_CamelCase()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var values = new PagingValues(items: 47, page: 3, itemsPer: 5, pagesPer: 4);
+		var list = new PagedList<int>(values, [11, 12, 13, 14, 15]);
+
+		// Act
+		var json = JsonSerializer.Serialize(list, opt);
+
+		// Assert
+		Assert.Contains("\"items\":47", json);
+		Assert.Contains("\"itemsPer\":5", json);
+		Assert.Contains("\"firstItem\":", json);
+		Assert.Contains("\"lastItem\":", json);
+		Assert.Contains("\"page\":3", json);
+		Assert.Contains("\"pages\":", json);
+		Assert.Contains("\"pagesPer\":4", json);
+		Assert.Contains("\"lowerPage\":", json);
+		Assert.Contains("\"upperPage\":", json);
+		Assert.Contains("\"skip\":", json);
+		Assert.Contains("\"take\":", json);
+	}
+
+	[Fact]
+	public void Writes_Values_When_IPagingValues_Is_A_Mock()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var mock = Substitute.For<IPagingValues>();
+		mock.Items.Returns(42ul);
+		mock.ItemsPer.Returns(7ul);
+		mock.Page.Returns(2ul);
+		var list = new PagedList<int>(mock, [1, 2]);
+
+		// Act
+		var json = JsonSerializer.Serialize(list, opt);
+
+		// Assert
+		Assert.Contains("\"items\":42", json);
+		Assert.Contains("\"itemsPer\":7", json);
+		Assert.Contains("\"page\":2", json);
+		Assert.Contains("\"items\":[1,2]", json);
+	}
+
+	[Fact]
+	public void Writes_Items_Of_Complex_Type()
+	{
+		// Arrange
+		var opt = GetOptions();
+		var values = new PagingValues(items: 2, page: 1);
+		var list = new PagedList<Foo>(values, [new Foo(1, "a"), new Foo(2, "b")]);
+
+		// Act
+		var json = JsonSerializer.Serialize(list, opt);
+
+		// Assert
+		Assert.Contains("\"items\":[{\"id\":1,\"name\":\"a\"},{\"id\":2,\"name\":\"b\"}]", json);
+	}
+
+	public sealed record class Foo(int Id, string Name);
+}

--- a/tests/Tests.Jeebs/Internals/JsonConverters/PagedListJsonConverter/_Setup.cs
+++ b/tests/Tests.Jeebs/Internals/JsonConverters/PagedListJsonConverter/_Setup.cs
@@ -1,0 +1,21 @@
+// Jeebs Unit Tests
+// Copyright (c) bfren - licensed under https://mit.bfren.dev/2013
+
+using System.Text.Json;
+
+namespace Jeebs.Internals.JsonConverters.PagedListJsonConverter_Tests;
+
+public abstract class Setup
+{
+	public JsonSerializerOptions GetOptions()
+	{
+		var opt = new JsonSerializerOptions
+		{
+			PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+		};
+		opt.Converters.Add(new ImmutableListJsonConverterFactory());
+		opt.Converters.Add(new PagedListJsonConverterFactory());
+
+		return opt;
+	}
+}


### PR DESCRIPTION
System.Text.Json silently serialised PagedList<T> as a bare array because it implements IEnumerable<T>, dropping the Values property entirely. And ImmutableList<T> couldn't be deserialised back from an array. Add JsonConverterFactory pairs for both types and register them on JsonF.Options so a caching service can round-trip these collections.